### PR TITLE
remove prompt arrow from shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,15 +159,15 @@ Build the project from source:
 
 1. Clone the Expected-Throwing-Value repository:
 ```sh
-❯ git clone https://github.com/BradenEberhard/Expected-Throwing-Value
+git clone https://github.com/BradenEberhard/Expected-Throwing-Value
 ```
 
 2. Navigate to the project directory:
 ```sh
-❯ cd Expected-Throwing-Value
+cd Expected-Throwing-Value
 ```
 
 3. Install the required dependencies (currently no requirements file):
 ```sh
-❯ pip install -r requirements.txt
+pip install -r requirements.txt
 ```


### PR DESCRIPTION
I use the same arrow. It's pretty, but adds an extra step to copying the commends.